### PR TITLE
To fix create tun device issue

### DIFF
--- a/docker.gateway.yaml
+++ b/docker.gateway.yaml
@@ -28,12 +28,12 @@ services:
     profiles:
       - worker
 
-
   server-quic:
     image: "??PRIVATE_REGISTRY/ferrumgate/secure.server.quic:1.1.0"
     labels:
       FerrumGatewayId: "??GATEWAY_ID"
     restart: always
+    privileged: true
     ports:
       - "??SSH_PORT:9999/tcp"
       - "??SSH_PORT:9999/udp"


### PR DESCRIPTION
Hi, I found the gateway couldn't create tun device while client connect to the gateway. 

The root cause is that the quic service runs in normal user mode. To fix this issue, need to add `privileged: true` in `docker.gateway.yaml`. 


Pls kindly review and merge the request. Thanks.